### PR TITLE
Make code PSR-2 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ must be installed and working on your system.** See the section below for detail
 
 ## History
 Every time i had convert url to pdf or to take screenshot of some url
-i had to install several libraries , i know there are very good libraries available 
+i had to install several libraries , i know there are very good libraries available
 like phantomJs,wkhtmltopdf and some others...
 but there are always rendering issue  
 like some supports **bootstrap** ,some not some time **html5 problem** etc..  
@@ -128,7 +128,7 @@ print "Image successfully generated :".$chrome->getScreenShot().PHP_EOL;
 
 ```
 
-### convert Html file to pdf 
+### convert Html file to pdf
 ```php
 
 include '../vendor/autoload.php';
@@ -143,7 +143,7 @@ print "Pdf successfully generated :".$chrome->getPdf().PHP_EOL;
 ```
 
 
-### convert Html code to pdf / screenshot 
+### convert Html code to pdf / screenshot
 ```php
 
 include '../vendor/autoload.php';
@@ -178,20 +178,20 @@ print "screenShot successfully generated :".$chrome->getScreenShot("/tmp/hello/t
 ## Setting options
 
 The `google-chrome` shell command accepts different types of options:
-for complete list of options you can visit 
+for complete list of options you can visit
 https://peter.sh/experiments/chromium-command-line-switches/
 
- 
+
 
 ### Wrapper Methods
 
 
- * `constructor`: Accepts $url to visit(for pdf/screenshot) as first parameter 
+ * `constructor`: Accepts $url to visit(for pdf/screenshot) as first parameter
  you can pass this as null and later use `setUrl`, and second parameter is binary
  path of google-chrome installed in your system as second parameter if no binaryPath is provided
  is uses default location `/usr/bin/google-chrome`
  but you still can provide binary path later using `setBinaryPath`,
- constructor also put some default arguments like 
+ constructor also put some default arguments like
  `headless , disable-gpu` which are necessary for google-chrome to work on cli
  * `setBinaryPath` which accepts binary path and set it for you
  * `setArguments` to set options of google-chrome it accepts array of options in a format
@@ -201,15 +201,15 @@ https://peter.sh/experiments/chromium-command-line-switches/
     $argument2=>$value2,  
  ]
  ```
-if your argument doesn't has values like `--headless` you can pass empty value 
+if your argument doesn't has values like `--headless` you can pass empty value
  e.g
  `[--headless=>'']`
 * `setArgument` to set option of google-chrome it accepts two parameter $argument , $value
  if your argument doesn't has a value like `--headless` you can pass empty value e.g
  `setArgument('--headless','')`
- 
+
 * `setChromeDirectory` the directory where google-chrome will save your profile
-    it is not mandatory as google-chrome by default uses some directory but in need 
+    it is not mandatory as google-chrome by default uses some directory but in need
     you can use this method to change that
 * `setUrl` to set the url to convert to pdf or to take screenshot    
 
@@ -220,29 +220,29 @@ if your argument doesn't has values like `--headless` you can pass empty value
 * `setOutputDirectory` directory to save the output (screenshots and pdf) the
 default directory is temporary directory of your operating system
 
-* `getPdf` it receives optional path parameter to save the pdf file at 
-if not provided it will save in output directory or temp directory of your 
+* `getPdf` it receives optional path parameter to save the pdf file at
+if not provided it will save in output directory or temp directory of your
 operating system depending if you properly set up the output directory,  
 for this check `setOutputDirectory` option,  
-it will convert your provided url to pdf and return the 
+it will convert your provided url to pdf and return the
 location of newly saved pdf
 
-* `getScreenShot` it receives optional path parameter to save the pdf file at 
-if not provided it will save in output directory or temp directory of your 
+* `getScreenShot` it receives optional path parameter to save the pdf file at
+if not provided it will save in output directory or temp directory of your
 operating system depending if you properly set up the output directory  
 for this check `setOutputDirectory` option,  
-it will take screenshot of your provided url and return the 
+it will take screenshot of your provided url and return the
 location of newly saved image
 
-* `setWindowSize` you can set the chrome window size using this method 
+* `setWindowSize` you can set the chrome window size using this method
 it accepts two parameters $width and $height
 
 * `useMobileScreen` ask chrome to access site as mobile browser
- 
+
 * `getArguments` returns all the arguments set
- 
+
 there are some other getters available too in case you need
- `getUrl , getBinaryPath , getOutPutDirectory`
+ `getUrl , getBinaryPath , getOutputDirectory`
 
 
 
@@ -250,7 +250,7 @@ there are some other getters available too in case you need
 
 ## Installation of google-Chrome (linux/mac )
 ```shell
-wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 
 sudo apt-get install libxss1 libappindicator1 libindicator7 libosmesa6
@@ -276,7 +276,7 @@ then try running `C:\Program Files (x86)\Google\Chrome\Application>chrome.exe --
 
 > Note  the path of chrome directory can be different in your case  
 
-## License 
+## License
 The **PhpChromeToPdf** is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
 
 ## Contribution

--- a/src/Chrome.php
+++ b/src/Chrome.php
@@ -1,246 +1,298 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: dawood ikhlaq <daudmalik06@gmail.com>
- * Date: 7/6/2017
- * Time: 10:53 PM
- */
-
 namespace dawood\phpChrome;
 
 use mikehaertl\shellcommand\Command;
+use Exception;
 
 class Chrome
 {
+    /**
+     * The location of the Chrome binary to be used
+     * @var string
+     */
     private $binaryPath;
-    private $arguments;
-    private $url;
-    private $outPutDirectory;
 
     /**
-     * Chrome constructor.
-     * @param null|string $url ,the url to convert to pdf
-     * @param null|string $binaryPath , location of google-chrome installed on your machine
-     * if no binaryPath is provided default will be used which is
-     * /usr/bin/google-chrome
+     * A list of arguments to execute Chrome with
+     * @var string
      */
-    function __construct($url=null, $binaryPath=null)
+    private $arguments;
+
+    /**
+     * The url that should be converted to a PDF
+     * @var string
+     */
+    private $url;
+
+    /**
+     * The directory to be used as output
+     * @var string
+     */
+    private $outputDirectory;
+
+    /**
+     * Chrome constructor
+     *
+     * @param string $url           The url to convert to a pdf
+     * @param string $binaryPath    Location of google-chrome installed on your machine
+     */
+    function __construct($url, $binaryPath = '/usr/bin/google-chrome')
     {
-        //some necessary default options
-        $this->setArguments(
-            [
-                '--headless'=>'',
-                '--disable-gpu'=>'',
-                '--incognito'=>'',
-                '--enable-viewport'=>'',
-            ]
-        );
+        // Set default options
+        $this->setArguments([
+            '--headless'=>'',
+            '--disable-gpu'=>'',
+            '--incognito'=>'',
+            '--enable-viewport'=>'',
+        ]);
+
         $this->setOutputDirectory(sys_get_temp_dir());
-        if(!$binaryPath)
-        {
-            $binaryPath='/usr/bin/google-chrome';
-        }
         $this->setBinaryPath($binaryPath);
-        if($url)
-        {
+
+        if ($url) {
             $this->setUrl($url);
         }
     }
 
     /**
-     * set the path of binary of google-chrome
-     * @param null|string $binaryPath
-     * @throws \Exception
+     * Set the binary to use for executing Chrome
+     *
+     * @param string $binaryPath
      */
-    public function setBinaryPath($binaryPath=null)
+    public function setBinaryPath($binaryPath)
     {
-        if(!$binaryPath)
-        {
-            throw new \Exception("No binary Bath Is provided");
-        }
-        $this->binaryPath=trim($binaryPath);
+        $this->binaryPath = trim($binaryPath);
         $this->abortIfChromeIsNotInstalled();
     }
 
     /**
-     * Directory where the browser stores the user profile
-     * @param null $location
-     * @throws \Exception
-     */
-    public function setChromeDirectory($location=null)
+     * Set the location of the browser's user profile
+     *
+     * @param string $location
+    */
+    public function setChromeDirectory($location)
     {
-        if(!$location)
-        {
-            throw new \Exception("No binary Bath Is provided");
-        }
-        $this->setArgument('user-data-dir',$location);
+        $this->setArgument('user-data-dir', $location);
     }
     /**
-     * add provided argument to $this->arguments array
+     * Add a single provided argument to the arguments to run Chrome with
+     *
      * @param string $argument
      * @param string $value
      */
     public function setArgument($argument, $value)
     {
-        $argument=trim($argument);
-        if(!empty($value) && !strstr($argument,'='))
-        {
-            $argument.='=';
+        $argument = trim($argument);
+        if (!empty($value) && !strstr($argument, '=')) {
+            $argument .= '=';
         }
-        $this->arguments[$argument]=trim($value);
+
+        $this->arguments[$argument] = trim($value);
     }
 
     /**
-     * set provided arguments
+     * Set a list of arguments
+     *
      * @param array $options
      */
     public function setArguments(array $arguments)
     {
-        foreach ($arguments as $argument=>$value)
-        {
-            $this->setArgument($argument,$value);
+        foreach ($arguments as $argument => $value) {
+            $this->setArgument($argument, $value);
         }
     }
 
     /**
-     * set the url to convert to pdf
-     * @param null|string $url
-     * @throws \Exception
+     * Set the target URL
+     *
+     * @param string $url
      */
-    public function setUrl($url=null)
+    public function setUrl($url)
     {
-        if(!$url)
-        {
-            throw new \Exception('No url provided');
-        }
-        $this->url=trim($url);
+        $this->url = trim($url);
     }
 
     /**
-     * convert the provided url to pdf and return the pdf's location
-     * @param string|null $pdfPath desired location and file to save the pdf file
-     * e.g /home/my.pdf
+     * Convert the provided URL to a PDF and return its location
+     *
+     * @param string $pdfPath   The path to the PDF
      * @return string
-     * @throws \Exception
+     * @throws Exception
      */
-    public function getPdf($pdfPath=null)
+    public function getPdf($pdfPath)
     {
-        if($pdfPath && !strstr($pdfPath,".pdf"))
-        {
-            $pdfPath.=".pdf";
+        if ($pdfPath && !strstr($pdfPath, '.pdf')) {
+            $pdfPath .= '.pdf';
         }
-        $pdfName=$this->returnUniqueName("pdf");
-        $printArray=[
-            '--print-to-pdf='=>$pdfPath?$pdfPath:$this->outPutDirectory.'/'.$pdfName,
+        $pdfName = $this->getUniqueName('pdf');
+
+        $location = $pdfPath ?: $this->outputDirectory . '/' . $pdfName;
+        $printArray = [
+            '--print-to-pdf=' => $location,
         ];
-        $allArguments=array_merge($printArray,$this->arguments);
-        if(!$this->executeChrome($allArguments))
-        {
-            throw new \Exception("Some Error Occurred While Getting Pdf");
+
+        $allArguments = array_merge($printArray, $this->arguments);
+        if (!$this->executeChrome($allArguments)) {
+            throw new Exception('Some Error Occurred While Getting Pdf');
         }
-        return $pdfPath?$pdfPath:$this->outPutDirectory.'/'.$pdfName;
+
+        return $location;
     }
 
     /**
-     * convert the provided url to image and return the image's location
-     * @param string|null $imagePath $ImagePath desired location and file to save the screenshot file
+     * Convert the provided url to image and return the image's location
+     *
+     * @param string $imagePath desired location and file to save the screenshot file
      * e.g /home/my.jpg
      * @return string
-     * @throws \Exception
+     * @throws Exception
      */
-    public function getScreenShot($imagePath=null)
+    public function getScreenShot($imagePath)
     {
-        if($imagePath && !strstr($imagePath,".jpg") && !strstr($imagePath,".png"))
-        {
-            $imagePath.=".jpg";
+        if ($imagePath && !strstr($imagePath, '.jpg') && !strstr($imagePath, '.png')) {
+            $imagePath .= '.jpg';
         }
-        $imageName=$this->returnUniqueName("jpg");
-        $printArray=[
-            '--screenshot='=>$imagePath?$imagePath:$this->outPutDirectory.'/'.$imageName,
+
+        $screenshotPath = $imagePath ?: $this->outputDirectory . '/' . $this->getUniqueName('jpg');
+        $printArray = [
+            '--screenshot=' => $screenshotPath,
         ];
-        $allArguments=array_merge($printArray,$this->arguments);
-        if(!$this->executeChrome($allArguments))
-        {
-            throw new \Exception("Some Error Occurred While Getting Image");
+
+        $allArguments = array_merge($printArray, $this->arguments);
+        if (!$this->executeChrome($allArguments)) {
+            throw new Exception('An error occured while getting the image');
         }
-        return $imagePath?$imagePath:$this->outPutDirectory.'/'.$imageName;
+
+        return $screenshotPath;
     }
 
     /**
-     * set the output directory to save the pdf and screenshotss
-     * @param null $directory
-     * @throws \Exception
+     * Set the output directory for PDF and screenshots
+     *
+     * @param string $directory
      */
-    public function setOutputDirectory($directory=null)
+    public function setOutputDirectory($directory)
     {
-        if(!$directory)
-        {
-            throw new \Exception('No url provided');
-        }
-        $this->outPutDirectory=trim($directory);
-        if(!file_exists($directory))
-        {
+        $this->outputDirectory = trim($directory);
+
+        if (!file_exists($directory)) {
             @mkdir($directory);
         }
     }
 
     /**
-     * execute the chrome using all the provided options
+     * Execute Chrome using all provided arguments
+     *
      * @param array $arguments
      */
     private function executeChrome(array $arguments)
     {
         $command = new Command($this->binaryPath);
-        foreach ($arguments as $argument=>$value)
-        {
-            $command->addArg($argument,$value?$value:null);
+        foreach ($arguments as $argument => $value) {
+            $command->addArg($argument, $value ? $value : null);
         }
-        $command->addArg($this->url,null);
-        if (!$command->execute())
-        {
-            echo $command->getError().PHP_EOL.'exit Code:'.$command->getExitCode();
+
+        $command->addArg($this->url, null);
+
+        if (!$command->execute()) {
+            echo $command->getError() . PHP_EOL;
+            echo 'Exit code: ' . $command->getExitCode() . PHP_EOL;
             return false;
         }
-        unset($command);
+
         return true;
     }
 
     /**
-     * check if provided fileName exist in our output directory
+     * Check if the provided file is unique and doesn't already exist in the
+     * output directory
+     *
      * @param string $fileName
-     * @return bool , true if provided fileName is unique i.e not present in output directory
-     *                false if provided fileNae is not unique , i.e is present in output directory
+     * @return bool
      */
-    private function UniqueName($fileName)
+    private function uniqueName($fileName)
     {
-        if(file_exists($this->outPutDirectory.'/'.$fileName))
-        {
-            return false;
-        }
-        return true;
+        return !file_exists($this->outputDirectory . '/' . $fileName);
     }
 
     /**
-     * set chrome window size
+     * Set the size of  the Chrome window
+     *
      * @param integer $width
      * @param integer $height
      */
     public function setWindowSize($width, $height)
     {
-        $this->setArgument('--window-size',$width.','.$height);
+        $this->setArgument('--window-size', $width . ',' . $height);
     }
 
     /**
-     *  tell's the chrome to use mobile screen
+     * Sets a mobile user agent for Chrome
      */
     public function useMobileScreen()
     {
-        $this->setArgument('--user-agent','Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30');
+        $this->setArgument('--user-agent', 'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30');
     }
 
     /**
-     * return $this->url
-     * @return mixed
+     * Set the provided filename as the target url using the file:// protocol
+     *
+     * @param string $file
+     * @throws Exception if file not found
+     */
+    public function useHtmlFile($file)
+    {
+        if (!file_exists($file)) {
+            throw new Exception("$file not found");
+        }
+
+        $this->setUrl("file://$file");
+    }
+
+    /**
+     * Allow using html code to be converted to pdf or to take screenshot
+     *
+     * @param string $html
+     */
+    public function useHtml($html)
+    {
+        $this->setUrl('data:text/html,' . rawurlencode($html));
+    }
+
+    /**
+     * Throws an exception if the provided chrome binary is not available
+     *
+     * @throws Exception
+     */
+    private function abortIfChromeIsNotInstalled()
+    {
+        $command = new Command(trim($this->binaryPath . ' --version'));
+        $command->execute();
+
+        $error = $command->getError();
+        if ($error && (!strstr($error, 'Google Chrome') || !strstr($error, 'Chromium'))) {
+            throw new Exception('Problem in running Chrome\'s binary: ' . $error);
+        }
+    }
+
+    /**
+     * Returns a unique filename with the given extension
+     *
+     * @return string
+     */
+    private function getUniqueName($extension)
+    {
+        do {
+            $uniqueName = md5(time() . mt_rand()) . '.' . $extension;
+        } while (!$this->uniqueName($uniqueName));
+
+        return $uniqueName;
+    }
+
+    /**
+     * Gets the Url
+     *
+     * @return string
      */
     public function getUrl()
     {
@@ -248,8 +300,9 @@ class Chrome
     }
 
     /**
-     * return currently used binary path
-     * @return mixed
+     * Get the path of the currently used binary
+     *
+     * @return string
      */
     public function getBinaryPath()
     {
@@ -257,7 +310,9 @@ class Chrome
     }
 
     /**
-     * @return mixed arguments to use with chrome
+     * Gets a list of all arguments that Chrome is launched with
+     *
+     * @return array
      */
     public function getArguments()
     {
@@ -265,62 +320,12 @@ class Chrome
     }
 
     /**
-     * @return string the output directory to be used by chrome
+     * Get the output directory to be used by Chrome
+     *
+     * @return string
      */
-    public function getOutPutDirectory()
+    public function getOutputDirectory()
     {
-        return $this->outPutDirectory;
+        return $this->outputDirectory;
     }
-
-    /**
-     * set the provided file as current url with file:// protocol
-     * @param string $file
-     * @throws \Exception if file not found
-     */
-    public function useHtmlFile($file)
-    {
-        if(!file_exists($file))
-        {
-            throw new \Exception("$file not found");
-        }
-        $this->setUrl("file://".$file);
-    }
-
-    /**
-     * allow using html code to be converted to pdf or to take screenshot
-     * @param string|null $html
-     * @throws \Exception
-     */
-    public function useHtml($html=null)
-    {
-        if(!$html)
-        {
-            throw new \Exception("No html provided");
-        }
-        $this->setUrl('data:text/html,' . rawurlencode($html));
-    }
-
-    /**
-     * @throws \Exception if the provided chrome's binary is not available/installed
-     */
-    private function abortIfChromeIsNotInstalled()
-    {
-        $command = new Command(trim($this->binaryPath.' --version'));
-        $command->execute();
-        if($command->getError() && (!strstr($command->getError(),"Google Chrome") || !strstr($command->getError(),"Chromium")))
-        {
-            throw new \Exception("there is problem in running provided chrome's binary Error message is :".$command->getError());
-        }
-    }
-
-    private function returnUniqueName($extension)
-    {
-        $uniqueName=md5(time().mt_rand()).'.'.$extension;
-        while(!$this->UniqueName($uniqueName))
-        {
-            $uniqueName=rand().$uniqueName;
-        }
-        return $uniqueName;
-    }
-
 }

--- a/src/Chrome.php
+++ b/src/Chrome.php
@@ -36,7 +36,7 @@ class Chrome
      * @param string $url           The url to convert to a pdf
      * @param string $binaryPath    Location of google-chrome installed on your machine
      */
-    function __construct($url, $binaryPath = '/usr/bin/google-chrome')
+    function __construct($url = '', $binaryPath = '')
     {
         // Set default options
         $this->setArguments([
@@ -47,7 +47,10 @@ class Chrome
         ]);
 
         $this->setOutputDirectory(sys_get_temp_dir());
-        $this->setBinaryPath($binaryPath);
+
+        if ($binaryPath) {
+            $this->setBinaryPath($binaryPath);
+        }
 
         if ($url) {
             $this->setUrl($url);
@@ -115,11 +118,11 @@ class Chrome
     /**
      * Convert the provided URL to a PDF and return its location
      *
-     * @param string $pdfPath   The path to the PDF
+     * @param null|string $pdfPath   The path to the PDF
      * @return string
      * @throws Exception
      */
-    public function getPdf($pdfPath)
+    public function getPdf($pdfPath = null)
     {
         if ($pdfPath && !strstr($pdfPath, '.pdf')) {
             $pdfPath .= '.pdf';
@@ -142,12 +145,12 @@ class Chrome
     /**
      * Convert the provided url to image and return the image's location
      *
-     * @param string $imagePath desired location and file to save the screenshot file
+     * @param null|string $imagePath desired location and file to save the screenshot file
      * e.g /home/my.jpg
      * @return string
      * @throws Exception
      */
-    public function getScreenShot($imagePath)
+    public function getScreenShot($imagePath = null)
     {
         if ($imagePath && !strstr($imagePath, '.jpg') && !strstr($imagePath, '.png')) {
             $imagePath .= '.jpg';

--- a/tests/ChromeTestSuite.php
+++ b/tests/ChromeTestSuite.php
@@ -4,13 +4,14 @@ use PHPUnit\Framework\TestCase;
 
 class ChromeTestSuite extends TestCase
 {
+    protected $binaryPath = '/usr/bin/google-chrome';
+    
     public function testChromeConstructorProperlySettingValues()
     {
         $url = 'http://example.com';
-        $binaryPath = '/usr/bin/google-chrome';
-        $chrome = new Chrome($url, $binaryPath);
+        $chrome = new Chrome($url, $this->binaryPath);
         $this->assertEquals($url, $chrome->getUrl());
-        $this->assertEquals($binaryPath, $chrome->getBinaryPath());
+        $this->assertEquals($this->binaryPath, $chrome->getBinaryPath());
     }
 
     public function testSetArguments()
@@ -22,7 +23,9 @@ class ChromeTestSuite extends TestCase
             '----timeout=' => '6000',
         ];
         $chrome = new Chrome();
+        $chrome->setBinaryPath($this->binaryPath);
         $chrome->setArguments($arguments);
+
         foreach ($arguments as $argument => $value) {
             $this->assertArrayHasKey($argument, $chrome->getArguments());
             $this->assertEquals($value, $chrome->getArguments()[$argument]);
@@ -32,9 +35,8 @@ class ChromeTestSuite extends TestCase
     public function testSetBinaryPath()
     {
         $chrome = new Chrome();
-        $binaryPath = '/usr/bin/google-chrome';
-        $chrome->setBinaryPath($binaryPath);
-        $this->assertEquals($binaryPath,$chrome->getBinaryPath());
+        $chrome->setBinaryPath($this->binaryPath);
+        $this->assertEquals($this->binaryPath,$chrome->getBinaryPath());
     }
 
     public function testSetChromeDirectory()
@@ -72,6 +74,8 @@ class ChromeTestSuite extends TestCase
     public function testGetPdf()
     {
         $chrome = new Chrome();
+        $chrome->setBinaryPath($this->binaryPath);
+
         $pdfLocation = $chrome->getPdf();
         $this->deleteFile($pdfLocation);
         $this->assertNotEmpty($pdfLocation);
@@ -80,6 +84,8 @@ class ChromeTestSuite extends TestCase
     public function testGetScreenshot()
     {
         $chrome = new Chrome();
+        $chrome->setBinaryPath($this->binaryPath);
+
         $imageLocation = $chrome->getScreenShot();
         $this->deleteFile($imageLocation);
         $this->assertNotEmpty($imageLocation);
@@ -128,6 +134,8 @@ class ChromeTestSuite extends TestCase
     public function testPdfPath()
     {
         $chrome = new Chrome();
+        $chrome->setBinaryPath($this->binaryPath);
+
         $pdfLocation = $chrome->getPdf('/tmp/test');
         $this->deleteFile($pdfLocation);
         $this->assertEquals("/tmp/test.pdf", $pdfLocation);
@@ -136,6 +144,8 @@ class ChromeTestSuite extends TestCase
     public function testScreenShotPath()
     {
         $chrome = new Chrome();
+        $chrome->setBinaryPath($this->binaryPath);
+
         $imageLocation = $chrome->getScreenShot("/tmp/jan");
         $this->deleteFile($imageLocation);
         $this->assertEquals("/tmp/jan.jpg", $imageLocation);

--- a/tests/ChromeTestSuite.php
+++ b/tests/ChromeTestSuite.php
@@ -2,15 +2,8 @@
 use dawood\phpChrome\Chrome;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Created by PhpStorm.
- * User: dawood Ikhlaq
- * Date: 7/8/2017
- * Time: 6:02 PM
- */
 class ChromeTestSuite extends TestCase
 {
-
     public function testChromeConstructorProperlySettingValues()
     {
         $url = 'http://example.com';
@@ -39,55 +32,55 @@ class ChromeTestSuite extends TestCase
     public function testSetBinaryPath()
     {
         $chrome = new Chrome();
-        $binaryPath='/usr/bin/google-chrome';
+        $binaryPath = '/usr/bin/google-chrome';
         $chrome->setBinaryPath($binaryPath);
         $this->assertEquals($binaryPath,$chrome->getBinaryPath());
     }
 
     public function testSetChromeDirectory()
     {
-        $chrome=new Chrome();
-        $userDirectory='/usr/tmp';
+        $chrome = new Chrome();
+        $userDirectory = '/usr/tmp';
         $chrome->setChromeDirectory($userDirectory);
-        $chromeArguments=$chrome->getArguments();
-        $this->assertArrayHasKey('user-data-dir=',$chromeArguments);
-        $this->assertEquals($userDirectory,$chromeArguments['user-data-dir=']);
+        $chromeArguments = $chrome->getArguments();
+        $this->assertArrayHasKey('user-data-dir=', $chromeArguments);
+        $this->assertEquals($userDirectory, $chromeArguments['user-data-dir=']);
     }
 
     public function testSetArgument()
     {
-        $chrome=new Chrome;
+        $chrome = new Chrome;
         $chrome->setArgument('   test     ','           Nothing         ');
-        $this->assertArrayHasKey('test=',$chrome->getArguments());
-        $this->assertEquals('Nothing',$chrome->getArguments()['test=']);
+        $this->assertArrayHasKey('test=', $chrome->getArguments());
+        $this->assertEquals('Nothing', $chrome->getArguments()['test=']);
     }
 
     public function testSetUrl()
     {
-        $chrome=new Chrome();
-        $chrome->setUrl('http://google.com  ');
-        $this->assertEquals('http://google.com',$chrome->getUrl());
+        $chrome = new Chrome();
+        $chrome->setUrl('http://google.com');
+        $this->assertEquals('http://google.com', $chrome->getUrl());
     }
 
     public function testSetOutputDirectory()
     {
-        $chrome=new Chrome();
-        $chrome->setOutputDirectory('/usr/home/   ');
-        $this->assertEquals('/usr/home/',$chrome->getOutPutDirectory());
+        $chrome = new Chrome();
+        $chrome->setOutputDirectory('/usr/home/');
+        $this->assertEquals('/usr/home/', $chrome->getOutputDirectory());
     }
 
     public function testGetPdf()
     {
-        $chrome=new Chrome();
-        $pdfLocation=$chrome->getPdf();
+        $chrome = new Chrome();
+        $pdfLocation = $chrome->getPdf();
         $this->deleteFile($pdfLocation);
         $this->assertNotEmpty($pdfLocation);
     }
 
     public function testGetScreenshot()
     {
-        $chrome=new Chrome();
-        $imageLocation=$chrome->getScreenShot();
+        $chrome = new Chrome();
+        $imageLocation = $chrome->getScreenShot();
         $this->deleteFile($imageLocation);
         $this->assertNotEmpty($imageLocation);
     }
@@ -98,52 +91,53 @@ class ChromeTestSuite extends TestCase
      */
     private function deleteFile($file)
     {
-        if(!file_exists($file))
+        if (!file_exists($file))
         {
             return false;
         }
+
         unlink($file);
     }
 
     public function testUseHtmlFile()
     {
-        $chrome=new Chrome();
-        $htmlFile=__DIR__.'/index.html';
-        file_put_contents($htmlFile,"");
+        $chrome = new Chrome();
+        $htmlFile = __DIR__ . '/index.html';
+        file_put_contents($htmlFile, '');
         $chrome->useHtmlFile($htmlFile);
-        $this->assertEquals("file://".$htmlFile,$chrome->getUrl());
+        $this->assertEquals("file://" . $htmlFile, $chrome->getUrl());
         @unlink($htmlFile);
     }
 
     public function testUseHtmlCode()
     {
-        $chrome=new Chrome();
-        $htmlCode='<h1>hello world</h1>';
+        $chrome = new Chrome();
+        $htmlCode = '<h1>hello world</h1>';
         $chrome->useHtml($htmlCode);
-        $this->assertEquals("data:text/html,".rawurlencode($htmlCode),$chrome->getUrl());
+        $this->assertEquals("data:text/html," . rawurlencode($htmlCode), $chrome->getUrl());
     }
 
     public function testSetBinaryShouldThrowException()
     {
         $chrome = new Chrome();
-        $binaryPath='/usr/wrong/google-chrome';
+        $binaryPath = '/usr/wrong/google-chrome';
         $this->expectException(\Exception::class);
         $chrome->setBinaryPath($binaryPath);
     }
 
     public function testPdfPath()
     {
-        $chrome=new Chrome();
-        $pdfLocation=$chrome->getPdf('/tmp/test');
+        $chrome = new Chrome();
+        $pdfLocation = $chrome->getPdf('/tmp/test');
         $this->deleteFile($pdfLocation);
-        $this->assertEquals("/tmp/test.pdf",$pdfLocation);
+        $this->assertEquals("/tmp/test.pdf", $pdfLocation);
     }
 
     public function testScreenShotPath()
     {
-        $chrome=new Chrome();
-        $imageLocation=$chrome->getScreenShot("/tmp/jan");
+        $chrome = new Chrome();
+        $imageLocation = $chrome->getScreenShot("/tmp/jan");
         $this->deleteFile($imageLocation);
-        $this->assertEquals("/tmp/jan.jpg",$imageLocation);
+        $this->assertEquals("/tmp/jan.jpg", $imageLocation);
     }
 }


### PR DESCRIPTION
For issue #11.

Updated the code and tests to be PSR-2 compliant. Might have missed some things, which will likely be picked up if the StyleCI PR is merged. Simplified some of the code and reworded some of the phpdocs.

I also renamed `getOutPutDirectory` to `getOutputDirectory` (since output is one word). This change is API breaking though, so you might want to verify if that's what you want. I'd also recommend the same with `getScreenShot` and rename it to `getScreenshot`, but didn't do that in this PR.